### PR TITLE
Avoid fatal error in monolog fomatter

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -302,5 +302,13 @@ class Message implements MessageInterface
         return array_filter($message, function ($message) {
             return is_bool($message) || strlen($message);
         });
+    } 
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this->toArray());
     }
 }


### PR DESCRIPTION
Catchable Fatal Error: Object of class Gelf\Message could not be converted to string
Symfony 3.2.*
monolog-bundle ^3.0